### PR TITLE
Feature: Returning ESM-2 hidden layers

### DIFF
--- a/esm2quinox/_esm2.py
+++ b/esm2quinox/_esm2.py
@@ -126,7 +126,7 @@ class ESM2Result(eqx.Module):
 
     hidden: Float[Array, "length embed_size"]
     logits: Float[Array, "length alphabet_size"]
-    all_hidden: list[Float[Array, "length embed_size"]]
+    all_hidden: Float[Array, "num_layers length embed_size"]
 
 
 class LogitHead(eqx.Module):

--- a/esm2quinox/_esm2.py
+++ b/esm2quinox/_esm2.py
@@ -119,12 +119,14 @@ def tokenise(
 
 class ESM2Result(eqx.Module):
     """The output result from calling `esm2quinox.ESM2.__call__`. Has the `.hidden`
-    representation from the final layer of the model, and the `.logits` (pre-softmax)
-    from mapping that hidden layers through a prediction head.
+    representation from the final layer of the model, the `.logits` (pre-softmax)
+    from mapping that hidden layers through a prediction head, and `.all_hidden`
+    which contains the outputs from all layers (including the final layer).
     """
 
     hidden: Float[Array, "length embed_size"]
     logits: Float[Array, "length alphabet_size"]
+    all_hidden: list[Float[Array, "length embed_size"]]
 
 
 class LogitHead(eqx.Module):
@@ -195,6 +197,9 @@ class ESM2(eqx.Module):
         self.layer_norm = eqx.nn.LayerNorm(embed_size)
         self.logit_head = LogitHead(embed_size, _alphabet_size, logit_key)
 
+    def __len__(self):
+        return self.num_layers
+
     @property
     def embedding(self):
         return eqx.nn.Embedding(
@@ -249,10 +254,14 @@ class ESM2(eqx.Module):
         def f(x, dynamic_layer):
             layer = eqx.combine(dynamic_layer, static_layer)
             x = layer(x, is_pad=is_pad)
-            return x, None
+            return x, x
 
-        x, _ = lax.scan(f, x, xs=dynamic_layers)
+        x, all_hidden = lax.scan(f, x, xs=dynamic_layers)
         hidden = jax.vmap(self.layer_norm)(x)
         logits = jax.vmap(self.logit_head)(hidden)
 
-        return ESM2Result(hidden=hidden, logits=logits)
+        return ESM2Result(
+            hidden=hidden,
+            logits=logits,
+            all_hidden=all_hidden,
+        )

--- a/esm2quinox/_esm2.py
+++ b/esm2quinox/_esm2.py
@@ -126,7 +126,7 @@ class ESM2Result(eqx.Module):
 
     hidden: Float[Array, "length embed_size"]
     logits: Float[Array, "length alphabet_size"]
-    all_hidden: Float[Array, "num_layers length embed_size"]
+    all_hidden: list[Float[Array, "length embed_size"]]
 
 
 class LogitHead(eqx.Module):
@@ -260,5 +260,5 @@ class ESM2(eqx.Module):
         return ESM2Result(
             hidden=hidden,
             logits=logits,
-            all_hidden=all_hidden,
+            all_hidden=list(all_hidden),
         )

--- a/esm2quinox/_esm2.py
+++ b/esm2quinox/_esm2.py
@@ -197,9 +197,6 @@ class ESM2(eqx.Module):
         self.layer_norm = eqx.nn.LayerNorm(embed_size)
         self.logit_head = LogitHead(embed_size, _alphabet_size, logit_key)
 
-    def __len__(self):
-        return self.num_layers
-
     @property
     def embedding(self):
         return eqx.nn.Embedding(

--- a/tests/test_esm.py
+++ b/tests/test_esm.py
@@ -116,3 +116,37 @@ def test_call_on_string(token_dropout, getkey):
     out2 = model(tokens)
     assert jnp.array_equal(out.hidden, out2.hidden)
     assert jnp.array_equal(out.logits, out2.logits)
+
+
+def test_all_hidden_output(getkey):
+    num_layers = 4
+    embed_size = 24
+    num_heads = 3
+    alphabet_size = 33
+
+    model = esm2quinox.ESM2(
+        num_layers=num_layers,
+        embed_size=embed_size,
+        num_heads=num_heads,
+        token_dropout=False,
+        key=getkey(),
+    )
+
+    # Test with tokenised input
+    protein = "SPIDERMAN"
+    [tokens] = esm2quinox.tokenise([protein])
+    seq_length = len(tokens)
+
+    out = model(tokens)
+
+    # Check all_hidden dimensions (should num_layers x length x embed_size)
+    assert out.all_hidden.shape == (num_layers, seq_length, embed_size), (
+        f"Expected all_hidden shape {(num_layers, seq_length, embed_size)}, "
+        f"got {out.all_hidden.shape}"
+    )
+
+    # Test with string input
+    out2 = model("SPIDERMAN")
+    assert out2.hidden.shape == (seq_length, embed_size)
+    assert out2.logits.shape == (seq_length, alphabet_size)
+    assert out2.all_hidden.shape == (num_layers, seq_length, embed_size)

--- a/tests/test_esm.py
+++ b/tests/test_esm.py
@@ -139,14 +139,25 @@ def test_all_hidden_output(getkey):
 
     out = model(tokens)
 
-    # Check all_hidden dimensions (should num_layers x length x embed_size)
-    assert out.all_hidden.shape == (num_layers, seq_length, embed_size), (
-        f"Expected all_hidden shape {(num_layers, seq_length, embed_size)}, "
-        f"got {out.all_hidden.shape}"
+    # Check all_hidden is a list with the right amount of elements
+    assert isinstance(out.all_hidden, list), (
+        f"Expected all_hidden to be a list, got {type(out.all_hidden)}"
     )
+    assert len(out.all_hidden) == num_layers, (
+        f"Expected all_hidden to have {num_layers} elements, got {len(out.all_hidden)}"
+    )
+    # Check each element has the right shape
+    for i, hidden in enumerate(out.all_hidden):
+        assert hidden.shape == (seq_length, embed_size), (
+            f"Expected all_hidden[{i}] shape {(seq_length, embed_size)}, "
+            f"got {hidden.shape}"
+        )
 
     # Test with string input
     out2 = model("SPIDERMAN")
     assert out2.hidden.shape == (seq_length, embed_size)
     assert out2.logits.shape == (seq_length, alphabet_size)
-    assert out2.all_hidden.shape == (num_layers, seq_length, embed_size)
+    assert isinstance(out2.all_hidden, list)
+    assert len(out2.all_hidden) == num_layers
+    for hidden in out2.all_hidden:
+        assert hidden.shape == (seq_length, embed_size)


### PR DESCRIPTION
Following up on the suggestion we talked about a few months back, this pull request introduces support for retrieving all hidden layers of the ESM2 model for layer sweeps and inspections. To achieve this, this PR extends the `ESM2Result` class and updates the model’s forward pass to gather and return these intermediate outputs. Tests have also been added to ensure the new features work as expected.

**Model output enhancements:**

* The `ESM2Result` class now includes a new `.all_hidden` attribute, which contains the hidden representations from all layers (including the final layer).
* The model's `_call` method is updated to collect and return the outputs from all layers in the `.all_hidden` field.

**Testing:**

* Added a new test, `test_all_hidden_output`, to verify that the `.all_hidden` output has the correct shape and is present when calling the model with both tokenized and string inputs.